### PR TITLE
update Pure CSS Bulma Responsive Nav Bar tutorial to bulma 0.4.0

### DIFF
--- a/content/code/css/bulma-responsive-navbar/index.html
+++ b/content/code/css/bulma-responsive-navbar/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS only Bulma nav bar</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.3.1/css/bulma.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.0/css/bulma.css" />
   <style>
     @media screen and (max-width: 768px) {
       #menu-toggle:checked + .nav-menu {
@@ -16,31 +16,29 @@
 <body>
 
 <nav class="nav">
-  <div class="container">
-    <div class="nav-left">
-      <a class="nav-item">
-        Theory and Practice
-      </a>
-    </div>
+  <div class="nav-left">
+    <a class="nav-item">
+      Theory and Practice
+    </a>
+  </div>
 
-    <label for="menu-toggle" class="nav-toggle">
-      <span></span>
-      <span></span>
-      <span></span>
-    </label>
-    <input type="checkbox" id="menu-toggle" class="is-hidden"/>
+  <label for="menu-toggle" class="nav-toggle">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
+  <input type="checkbox" id="menu-toggle" class="is-hidden"/>
 
-    <div class="nav-right nav-menu">
-      <a class="nav-item">
-        About
-      </a>
-      <a class="nav-item">
-        Archives
-      </a>
-      <a class="nav-item">
-        Tags
-      </a>
-    </div>
+  <div class="nav-right nav-menu">
+    <a class="nav-item">
+      About
+    </a>
+    <a class="nav-item">
+      Archives
+    </a>
+    <a class="nav-item">
+      Tags
+    </a>
   </div>
 </nav>
 


### PR DESCRIPTION
hi,
thanks for the great [tutorial](https://siongui.github.io/2017/02/22/css-only-bulma-responsive-navbar/)!

i've just found out that you could easily update the tutorial to bulma 0.4.0 by deleting the container div inside the nav:

```
<nav class="nav">
  <div class="container">    <---
    <div class="nav-left">
      <a class="nav-item">
        ...
```

bye!