### PR TITLE
Modal background now also toggles modal

### DIFF
--- a/content/articles/2018/01/27/css-only-toggle-bulma-modal%en.rst
+++ b/content/articles/2018/01/27/css-only-toggle-bulma-modal%en.rst
@@ -30,7 +30,7 @@ CSS only toggle Bulma_ modal_. Click the following button to see demo.
 
   <!-- Modal -->
   <div class="modal" id="myModal">
-    <div class="modal-background"></div>
+    <label for="element-toggle" class="modal-background"></label>
     <div class="modal-content">
       <p class="image is-4by3">
         <img src="https://bulma.io/images/placeholders/1280x960.png" alt="image modal">
@@ -57,7 +57,7 @@ The following is the source code for above demo.
 
   <!-- Modal -->
   <div class="modal" id="myModal">
-    <div class="modal-background"></div>
+    <label for="element-toggle" class="modal-background"></label>
     <div class="modal-content">
       <p class="image is-4by3">
         <img src="https://bulma.io/images/placeholders/1280x960.png" alt="image modal">


### PR DESCRIPTION
By making the modal-background a label element, selecting it can close the modal too, as per typical modal behaviour.

Reference used:
https://codeshack.io/pure-css3-modal-example/